### PR TITLE
Remove required_files section from rcx_upsetplot.xml

### DIFF
--- a/tools/upsetr/rcx_upsetplot.xml
+++ b/tools/upsetr/rcx_upsetplot.xml
@@ -8,9 +8,6 @@
         <requirement type="package" version="@TOOL_VERSION@">r-upsetr</requirement>
         <requirement type="package" version="24.0.0">r-arrow</requirement>
     </requirements>
-    <required_files>
-        <include path="utils.r" />
-    </required_files>
 
     <creator>
         <person


### PR DESCRIPTION
Removed unnecessary required_files section from XML.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
